### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![ci](https://github.com/scivision/pypistats-plots/workflows/ci/badge.svg)
 
 Plots using
-[pypistats API](https://github.com/hugovk/pypistats).
-As it is currently, the PyPiStats API seems to be more "printing tables" oriented rather than "comparing plots" oriented.
+[pypistats library](https://github.com/hugovk/pypistats).
+As it is currently, the pypistats library seems to be more "printing tables" oriented rather than "comparing plots" oriented.
 Thus we created this script to plot data instead.
 Our first interest in creating this addendum project was to gauge relative use of minor Python versions to decide when to cutoff EOL Python versions e.g. Python 3.5.
 
@@ -24,4 +24,4 @@ There is no install--just run the script like:
 python plot_pypistats.py meson
 ```
 
-to plot statistics on PyPi package "Meson"
+to plot statistics on PyPI package "Meson"

--- a/plot_pypistats.py
+++ b/plot_pypistats.py
@@ -49,7 +49,7 @@ def plot_trends(normed: pandas.DataFrame, versions: list[str]):
     axs = fg.subplots(2, 1, sharex=True)
     normed.plot(ax=axs[0])
     axs[0].set_title(
-        f"{normed.attrs['project_name']}: PyPi downloads by Python version (pypistats.org): {normed.attrs['window']} week average"
+        f"{normed.attrs['project_name']}: PyPI downloads by Python version (pypistats.org): {normed.attrs['window']} week average"
     )
     axs[0].set_ylabel("normalized downloads")
     axs[0].legend(loc="center left")
@@ -66,7 +66,7 @@ def plot_trends(normed: pandas.DataFrame, versions: list[str]):
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
-    p.add_argument("projname", help="PyPi project name")
+    p.add_argument("projname", help="PyPI project name")
     p.add_argument(
         "-w", "--window", help="time window to average over (weeks)", type=int, default=1
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = pypistatsplots
 version = 1.2.0
 author = Michael Hirsch, Ph.D.
 author_email = scivision@users.noreply.github.com
-description = Plot Python package data from PyPistats
+description = Plot Python package data from pypistats
 url = https://github.com/scivision/pypistats-plots
 keywords =
   pypi


### PR DESCRIPTION
Hi! This looks really useful, thanks!

This PR fixes a typo, it's [PyPI](https://pypi.org/) not PyPi.

Also, my [pypistats](https://github.com/hugovk/pypistats) library uses the [PyPI Stats API](https://pypistats.org/api/) :)